### PR TITLE
Fixing error that occurs on a clean install with TaxJar present.

### DIFF
--- a/Observer/ImportCategories.php
+++ b/Observer/ImportCategories.php
@@ -99,7 +99,15 @@ class ImportCategories implements ObserverInterface
         $this->categoryFactory = $categoryFactory;
         $this->categoryResourceModel = $categoryResourceModel;
         $this->taxjarConfig = $taxjarConfig;
-        $this->apiKey = $this->taxjarConfig->getApiKey();
+    }
+    
+    private function getApiKey()
+    {
+        if (!$this->apiKey) {
+            $this->apiKey = $this->taxjarConfig->getApiKey();
+        }
+        
+        return $this->apiKey;
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -17,6 +17,12 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager:etc/config.xsd">
+    <type name="Taxjar\SalesTax\Console\Command\SyncTransactionsCommand">
+        <arguments>
+            <argument name="backfill" xsi:type="object">Taxjar\SalesTax\Model\Transaction\Backfill\Proxy</argument>
+        </arguments>
+    </type>
+    
     <preference for="Magento\Tax\Model\Sales\Total\Quote\Tax" type="Taxjar\SalesTax\Model\Tax\Sales\Total\Quote\Tax" />
     <preference for="Taxjar\SalesTax\Api\Data\Tax\NexusSearchResultsInterface" type="Magento\Framework\Api\SearchResults" />
     <preference for="Taxjar\SalesTax\Api\Data\Tax\NexusInterface" type="Taxjar\SalesTax\Model\Tax\Nexus" />


### PR DESCRIPTION
### Context
When installing Magento (after the TaxJar module has already been installed via composer, example is a build environment), we get this error:
```
Base table or view not found: 1146 Table ‘build_db.core_config_data’ doesn’t exist, query was: SELECT `main_table`.* FROM `core_config_data` AS `main_table`
```

### Description
This happens because the constructor fetched the information (ultimately from `core_config_data`) before this table was created. I've found that constructors are not an ideal place to fetch information, for this reason. The class is initialized before the schema creation happens.

### Performance
It now works :).

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Use composer to require Magento
2. Use composer to require the TaxJar module
3. Then run `bin/magento setup:install`.

#### Versions
<!-- What version(s) did you test this change on? -->
- [ ] Magento 2.4
- [x] Magento 2.3
- [ ] Magento 2.2
- [ ] Magento 2.1
<!-- What edition(s) of Magento did you test this change on? -->
- [x] Magento Open Source (CE)
- [ ] Magento Commerce (EE)
- [ ] Magento B2B
- [ ] Magento Cloud
<!-- What version of PHP did you test this change on? -->
- [x] PHP 7.x
- [ ] PHP 5.x
